### PR TITLE
class_inheritable_attribute deprecated in rails 3.1 beta

### DIFF
--- a/lib/supermodel/base.rb
+++ b/lib/supermodel/base.rb
@@ -1,6 +1,6 @@
 module SuperModel
   class Base    
-    class_inheritable_array :known_attributes
+    class_attribute :known_attributes
     self.known_attributes = []
     
     class << self

--- a/supermodel.gemspec
+++ b/supermodel.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activemodel>, ["~> 3.0.0"])
+      s.add_runtime_dependency(%q<activemodel>, [">= 3.0.0"])
     else
       s.add_dependency(%q<activemodel>, ["~> 3.0.0"])
     end


### PR DESCRIPTION
Updated the active model dependency and replaced class_inheritable_attribute with class_attribute as per the deprecation warning. Since no tests, I couldn't run against a test suite but all my tests pass. I, however, have extended supermodel quite a bit.
