### PR TITLE
Added #where to base.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ redis_test.rb
 pkg
 lib/supermodel/cassandra.rb
 *.gem
+tags

--- a/lib/supermodel/base.rb
+++ b/lib/supermodel/base.rb
@@ -54,6 +54,19 @@ module SuperModel
         item = records.values[-1]
         item && item.dup
       end
+
+      def where(options)
+        items = records.values.select do |r|
+          options.all? do |k, v|
+            if v.is_a?(Enumerable)
+              v.include?(r.send(k))
+            else
+              r.send(k) == v
+            end
+          end
+        end
+        collection.new(items.deep_dup)
+      end
       
       def exists?(id)
         records.has_key?(id)


### PR DESCRIPTION
Added a basic implementation of #where to base.rb, filters by all the given keys doing an effective sql 'AND' for all. Each key can have a single or multiple (Array) values, in case it's single it's simple, in case it's multiple, it will look for all values.

Simplified example of how it should work :

``` ruby
Model.where(:id => [1,2]) #=> [#<Model ID=1...>, #<Model ID=2...>]
Model.where(:id => 1, :name => 'test') #=> [#<Model ID=1 NAME='test'...>]
```
