### PR TITLE
Rails 4 compatibility

### DIFF
--- a/lib/supermodel/callbacks.rb
+++ b/lib/supermodel/callbacks.rb
@@ -11,7 +11,7 @@ module SuperModel
       %w( create save update destroy ).each do |method|
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def #{method}_with_callbacks(*args, &block)
-            _run_#{method}_callbacks do
+            run_callbacks :#{method} do
               #{method}_without_callbacks(*args, &block)
             end
           end


### PR DESCRIPTION
Prefer calling actual rails callbacks API method over private rails method.  This private rails method (_run_X_callbacks) changed in rails 4, which broke this code.  With these changes, supermodel should be compatible with rails 3 and 4.
